### PR TITLE
feat: add stats api and refactor today card

### DIFF
--- a/src/app/api/stats/today/route.ts
+++ b/src/app/api/stats/today/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getTodayStats } from '@/lib/stats';
+
+export async function GET() {
+  const stats = await getTodayStats();
+  return NextResponse.json(stats);
+}

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -148,3 +148,5 @@ function useWeeklySummary(rows: DayAgg[]) {
       ...w,
       weekOfMonth: w.weekStart.isoWeek() - w.weekStart.startOf("month").isoWeek() + 1,
     }));
+  }, [rows]);
+}

--- a/src/app/components/TodayStatsCard.tsx
+++ b/src/app/components/TodayStatsCard.tsx
@@ -3,12 +3,16 @@
 import useSWR from 'swr';
 import { Card, Statistic } from 'antd';
 
+type Stats = { pnl: number; trades: number; rr: number };
+
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
-export default function TodayStatsCard() {
-  const { data = { pnl: 0, trades: 0, rr: 0 } } = useSWR('/api/stats/today', fetcher, {
-    refreshInterval: 15000,
-  });
+export default function TodayStatsCard({ initial }: { initial?: Stats }) {
+  const { data = { pnl: 0, trades: 0, rr: 0 } } = useSWR<Stats>(
+    '/api/stats/today',
+    fetcher,
+    { refreshInterval: 15000, fallbackData: initial }
+  );
 
   return (
     <Card className="shadow-md rounded-lg w-full max-w-md">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,89 +1,7 @@
-import { Card, Statistic, Button } from 'antd';
+import { Button } from 'antd';
 import Link from 'next/link';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
-
-
-// Helper functions (same as before)
-function num(t: any, keys: string[]) {
-  for (const k of keys) {
-    const v = t?.[k];
-    if (v !== undefined && v !== null && !Number.isNaN(Number(v))) return Number(v);
-  }
-  return NaN;
-}
-function dt(t: any, keys: string[]) {
-  for (const k of keys) {
-    const v = t?.[k];
-    if (v) return new Date(v);
-  }
-  return null;
-}
-function isToday(d: Date | null) {
-  if (!d) return false;
-  const now = new Date();
-  return (
-    d.getFullYear() === now.getFullYear() &&
-    d.getMonth() === now.getMonth() &&
-    d.getDate() === now.getDate()
-  );
-}
-function realizedPnl(t: any) {
-  const side = (t?.side ?? '').toString().toUpperCase();
-  const entry = num(t, ['entry', 'entryPrice', 'avgEntry']);
-  const exit = num(t, ['exitPrice', 'closePrice', 'avgExit']);
-  const size = num(t, ['size', 'quantity']);
-  const fees = num(t, ['fees', 'commission']);
-  if ([entry, exit, size].some((x) => Number.isNaN(x))) return 0;
-  const gross = side === 'SHORT' ? (entry - exit) * size : (exit - entry) * size;
-  return gross - (Number.isNaN(fees) ? 0 : fees);
-}
-function rrRatio(t: any): number | null {
-  const entry = num(t, ['entry', 'entryPrice']);
-  const exit = num(t, ['exitPrice', 'closePrice']);
-  const sl = num(t, ['stopLoss', 'sl']);
-  if ([entry, exit, sl].some((x) => Number.isNaN(x))) return null;
-  const risk = Math.abs(entry - sl);
-  if (risk === 0) return null;
-  const reward = Math.abs(exit - entry);
-  return reward / risk;
-}
-
-async function getTodayStats() {
-  let session = null;
-  try {
-    session = await getServerSession(authOptions);
-  } catch (err) {
-    console.error('Error getting session:', err);
-    return { pnl: 0, trades: 0, rr: 0 };
-  }
-
-  if (!session?.user?.email) return { pnl: 0, trades: 0, rr: 0 };
-
-  const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
-    select: { id: true },
-  });
-  if (!user) return { pnl: 0, trades: 0, rr: 0 };
-
-  const trades = (await prisma.trade.findMany({
-    where: { userId: user.id },
-    orderBy: { updatedAt: 'desc' },
-    take: 500,
-  })) as any[];
-
-  const closedToday = trades.filter((t) =>
-    isToday(dt(t, ['exitAt', 'closedAt', 'updatedAt']))
-  );
-
-  const pnl = closedToday.reduce((acc, t) => acc + realizedPnl(t), 0);
-  const rrs = closedToday.map(rrRatio).filter((v): v is number => v !== null && isFinite(v));
-  const rrAvg = rrs.length ? Number((rrs.reduce((a, b) => a + b, 0) / rrs.length).toFixed(2)) : 0;
-
-  return { pnl, trades: closedToday.length, rr: rrAvg };
-}
-
+import TodayStatsCard from './components/TodayStatsCard';
+import { getTodayStats } from '@/lib/stats';
 
 export default async function Home() {
   const stats = await getTodayStats();
@@ -103,14 +21,7 @@ export default async function Home() {
         </div>
       </section>
 
-      <Card className="shadow-md rounded-lg w-full max-w-md">
-        <h2 className="text-lg font-semibold mb-4">Today at a glance</h2>
-        <div className="grid grid-cols-3 gap-4">
-          <Statistic title="P&L" value={stats.pnl} precision={2} prefix={stats.pnl >= 0 ? '+' : ''} />
-          <Statistic title="Trades" value={stats.trades} />
-          <Statistic title="R/R" value={stats.rr} precision={2} />
-        </div>
-      </Card>
+      <TodayStatsCard initial={stats} />
 
       <footer className="mt-16 text-gray-500 text-sm">
         © {new Date().getFullYear()} Trade Journal

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,38 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function getTodayStats() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) return { pnl: 0, trades: 0, rr: 0 };
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { id: true },
+  });
+  if (!user) return { pnl: 0, trades: 0, rr: 0 };
+
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const end = new Date(start);
+  end.setDate(start.getDate() + 1);
+
+  const { _sum, _avg, _count } = await prisma.trade.aggregate({
+    where: {
+      userId: user.id,
+      closedAt: {
+        gte: start,
+        lt: end,
+      },
+    },
+    _sum: { realizedPnl: true },
+    _avg: { rr: true },
+    _count: { _all: true },
+  });
+
+  return {
+    pnl: Number(_sum.realizedPnl ?? 0),
+    trades: _count._all,
+    rr: _avg.rr ? Number(_avg.rr) : 0,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts"
   ]
 }
-

--- a/types/bcryptjs.d.ts
+++ b/types/bcryptjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'bcryptjs';


### PR DESCRIPTION
## Summary
- centralize daily stats logic with Prisma aggregate
- expose `/api/stats/today` endpoint
- refactor TodayStatsCard and home page to use shared stats
- fix calendar weekly summary closure and typing issues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da0fa71488327bef5acc8446543f7